### PR TITLE
Fixed "Deno is undefined" error in client

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,14 +1,5 @@
 import React from 'https://dev.jspm.io/react@16.13.1';
 import ReactDomServer from 'https://dev.jspm.io/react-dom@16.13.1/server';
-import {
-  Application,
-  Router,
-  Context,
-  send,
-} from 'https://deno.land/x/oak@v6.0.1/mod.ts';
+import ReactDom from 'https://dev.jspm.io/react-dom@16.13.1';
 
-// import { superoak } from 'https://deno.land/x/superoak@2.1.0/mod.ts';
-// import { describe, it } from 'https://deno.land/x/superoak@2.1.0/test/utils.ts';
-// import { expect } from 'https://deno.land/x/superoak@2.1.0/test/deps.ts';
-
-export { React, ReactDomServer, Application, Router, Context, send };
+export { React, ReactDomServer, ReactDom };

--- a/server.tsx
+++ b/server.tsx
@@ -1,4 +1,5 @@
-import { Application, Router, React, ReactDomServer } from './deps.ts';
+import { Application, Router } from './serverDeps.ts';
+import { React, ReactDomServer } from './deps.ts';
 import App from './client/app.tsx';
 import { staticFileMiddleware } from './staticFileMiddleware.ts';
 
@@ -75,7 +76,7 @@ function handlePage(ctx: any) {
   </head>
   <body >
     <div id="root">${body}</div>
-    <script  src="http://localhost:${PORT}/static/client.js" defer></script>
+    <script  src="/static/client.js" defer></script>
   </body>
   </html>`;
   } catch (error) {

--- a/serverDeps.ts
+++ b/serverDeps.ts
@@ -1,0 +1,8 @@
+import {
+  Application,
+  Router,
+  Context,
+  send,
+} from 'https://deno.land/x/oak@v6.0.1/mod.ts';
+
+export { Application, Router, Context, send };

--- a/staticFileMiddleware.ts
+++ b/staticFileMiddleware.ts
@@ -1,4 +1,4 @@
-import { Context, send } from './deps.ts';
+import { Context, send } from './serverDeps.ts';
 
 export const staticFileMiddleware = async (ctx: Context, next: Function) => {
   const path = `${Deno.cwd()}/client${ctx.request.url.pathname}`;


### PR DESCRIPTION
### Fixed "Deno is undefined" error in client

- Separated frontend and server dependencies into separate files in order to avoid serving backend Deno libraries to client