### PR TITLE
Blocked import of Code Blocks library

### DIFF
--- a/client/Components/DocPages/Overview.tsx
+++ b/client/Components/DocPages/Overview.tsx
@@ -1,4 +1,6 @@
-import { React, CodeBlock, monokai } from '../../../deps.ts';
+import { React, 
+  // CodeBlock, monokai 
+} from '../../../deps.ts';
 
 const Overview = (props: any) => {
 

--- a/client/Components/DocPages/Philosophy.tsx
+++ b/client/Components/DocPages/Philosophy.tsx
@@ -1,4 +1,6 @@
-import { React, CodeBlock, monokai } from '../../../deps.ts';
+import { React, 
+  // CodeBlock, monokai 
+} from '../../../deps.ts';
 
 
 

--- a/client/Components/DocPages/QuickStart.tsx
+++ b/client/Components/DocPages/QuickStart.tsx
@@ -17,7 +17,11 @@ const QuickStart = (props: any) => {
         showLineNumbers={false}
         theme={monokai}
       /> */}
-      <code>{"import { ObsidianRouter } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';"}</code>
+      <pre>
+        <code>
+          {"import { ObsidianRouter } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';"}
+        </code>
+      </pre>
       <br/>
       <p>In the app:</p>
       {/* <CodeBlock
@@ -26,7 +30,11 @@ const QuickStart = (props: any) => {
         showLineNumbers={false}
         theme={monokai}
       /> */}
-      <code>{"import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';"}</code>
+      <pre>
+        <code>
+          {"import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';"}
+        </code>
+      </pre>
       <br/>
       <h2>Creating the Router</h2>
       {/* <CodeBlock
@@ -63,6 +71,39 @@ await app.listen({ port: PORT });`}
         showLineNumbers={true}
         theme={monokai}
       /> */}
+      <pre>
+        <code>
+        {`import { Application, Router } from 'https://deno.land/x/oak@v6.0.1/mod.ts';
+import { ObsidianRouter, gql } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';
+
+const PORT = 8000;
+
+const app = new Application();
+
+const types = (gql as any)\`
+  // Type definitions
+\`;
+
+const resolvers = {
+  // Resolvers
+}
+
+interface ObsRouter extends Router {
+  obsidianSchema?: any;
+}
+
+const GraphQLRouter = await ObsidianRouter<ObsRouter>({
+  Router,
+  typeDefs: types,
+  resolvers: resolvers,
+  redisPort: 6379,
+});
+
+app.use(GraphQLRouter.routes(), GraphQLRouter.allowedMethods());
+
+await app.listen({ port: PORT });`}
+        </code>
+      </pre>
       <br/>
       <h2>Sending ObsidianSchema</h2>
       {/* <CodeBlock
@@ -104,6 +145,44 @@ app.use(router.routes(), router.allowedMethods());`}
         showLineNumbers={true}
         theme={monokai}
       /> */}
+      <pre>
+        <code>
+        {`interface initialState {
+  obsidianSchema?: any;
+}
+
+const initialState: initialState = {
+  obsidianSchema: GraphQLRouter.obsidianSchema
+}
+
+const router = new Router();
+router.get('/', handlePage);
+
+function handlePage(ctx: any) {
+  try {
+    const body = (ReactDomServer as any).renderToString(<App />);
+    ctx.response.body = \`<!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <title>SSR React App</title>
+        <script>
+          window.__INITIAL_STATE__ = \${JSON.stringify(initialState)};
+        </script>
+      </head>
+      <body>
+        <div id="root">\${body}</div>
+        <script src="/static/client.tsx" defer></script>
+      </body>
+      </html>\`;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+app.use(router.routes(), router.allowedMethods());`}
+        </code>
+      </pre>
       <br/>
       <h2>Creating the Wrapper</h2>
       {/* <CodeBlock
@@ -120,6 +199,19 @@ const App = () => {
         showLineNumbers={true}
         theme={monokai}
       /> */}
+      <pre>
+        <code>
+        {`import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';
+
+const App = () => {
+  return (
+    <ObsidianWrapper>
+      <WeatherApp />
+    </ObsidianWrapper>
+  );
+};`}
+        </code>
+      </pre>
       <br/>
       <h2>Making a Query</h2>
       {/* <CodeBlock
@@ -143,6 +235,26 @@ const WeatherApp = () => {
         showLineNumbers={true}
         theme={monokai}
       /> */}
+      <pre>
+        <code>
+        {`import { useObsidian } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';
+
+const WeatherApp = () => {
+  const { gather } = useObsidian();
+  const [weather, setWeather] = (React as any).useState('Sunny');
+
+  return (
+    <h1>{weather}</h1>
+    <button
+      onClick={() => {
+        gather(\`query { getWeather { id description } }\`)
+        .then(resp => setWeather(resp.data.getWeather.description))
+      }}
+    >Get Weather</button>
+  );
+};`}
+        </code>
+      </pre>
       <br/>
     </div>
   )

--- a/client/Components/DocPages/QuickStart.tsx
+++ b/client/Components/DocPages/QuickStart.tsx
@@ -1,4 +1,6 @@
-import { React, CodeBlock, monokai } from '../../../deps.ts';
+import { React, 
+  // CodeBlock, monokai 
+} from '../../../deps.ts';
 
 const QuickStart = (props: any) => {
 
@@ -9,23 +11,25 @@ const QuickStart = (props: any) => {
       <p>Optimized for use in server-side rendered React apps built with Deno, full stack integration of <code className="obsidianInline">obsidian</code> enables many of its most powerful features, including optimized caching exchanges between client and server and extremely lightweight client-side caching.</p>
       <h2>Installation</h2>
       <p>In the server:</p>
-      <CodeBlock
+      {/* <CodeBlock
         text={"import { ObsidianRouter } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';"}
         language={"typescript"}
         showLineNumbers={false}
         theme={monokai}
-      />
+      /> */}
+      <code>{"import { ObsidianRouter } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';"}</code>
       <br/>
       <p>In the app:</p>
-      <CodeBlock
+      {/* <CodeBlock
         text={"import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';"}
         language={"typescript"}
         showLineNumbers={false}
         theme={monokai}
-      />
+      /> */}
+      <code>{"import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';"}</code>
       <br/>
       <h2>Creating the Router</h2>
-      <CodeBlock
+      {/* <CodeBlock
         text={`import { Application, Router } from 'https://deno.land/x/oak@v6.0.1/mod.ts';
 import { ObsidianRouter, gql } from 'https://deno.land/x/obsidian@v1.0.1/mod.ts';
 
@@ -58,10 +62,10 @@ await app.listen({ port: PORT });`}
         language={"typescript"}
         showLineNumbers={true}
         theme={monokai}
-      />
+      /> */}
       <br/>
       <h2>Sending ObsidianSchema</h2>
-      <CodeBlock
+      {/* <CodeBlock
         text={`interface initialState {
   obsidianSchema?: any;
 }
@@ -99,10 +103,10 @@ app.use(router.routes(), router.allowedMethods());`}
         language={"tsx"}
         showLineNumbers={true}
         theme={monokai}
-      />
+      /> */}
       <br/>
       <h2>Creating the Wrapper</h2>
-      <CodeBlock
+      {/* <CodeBlock
         text={`import { ObsidianWrapper } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';
 
 const App = () => {
@@ -115,10 +119,10 @@ const App = () => {
         language={"tsx"}
         showLineNumbers={true}
         theme={monokai}
-      />
+      /> */}
       <br/>
       <h2>Making a Query</h2>
-      <CodeBlock
+      {/* <CodeBlock
         text={`import { useObsidian } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';
 
 const WeatherApp = () => {
@@ -138,7 +142,7 @@ const WeatherApp = () => {
         language={"tsx"}
         showLineNumbers={true}
         theme={monokai}
-      />
+      /> */}
       <br/>
     </div>
   )

--- a/client/Components/Docs.tsx
+++ b/client/Components/Docs.tsx
@@ -4,20 +4,20 @@ import QuickStart from './DocPages/QuickStart.tsx';
 import Philosophy from './DocPages/Philosophy.tsx';
 import Overview from './DocPages/Overview.tsx';
 
-import Persistence from './DocPages/Advanced/Persistence.tsx';
-import Polling from './DocPages/Advanced/Polling.tsx';
-import Subscriptions from './DocPages/Advanced/Subscriptions.tsx';
+// import Persistence from './DocPages/Advanced/Persistence.tsx';
+// import Polling from './DocPages/Advanced/Polling.tsx';
+// import Subscriptions from './DocPages/Advanced/Subscriptions.tsx';
 
-import BasicsErrors from './DocPages/Basics/Errors.tsx';
-import GettingStarted from './DocPages/Basics/GettingStarted.tsx';
-import Mutations from './DocPages/Basics/Mutations.tsx';
-import Queries from './DocPages/Basics/Queries.tsx';
-import ServerSideRendering from './DocPages/Basics/ServerSideRendering.tsx';
+// import BasicsErrors from './DocPages/Basics/Errors.tsx';
+// import GettingStarted from './DocPages/Basics/GettingStarted.tsx';
+// import Mutations from './DocPages/Basics/Mutations.tsx';
+// import Queries from './DocPages/Basics/Queries.tsx';
+// import ServerSideRendering from './DocPages/Basics/ServerSideRendering.tsx';
 
-import Client from './DocPages/Caching/Client.tsx';
-import CachingErrors from './DocPages/Caching/Errors.tsx';
-import Server from './DocPages/Caching/Server.tsx';
-import Strategies from './DocPages/Caching/Strategies.tsx';
+// import Client from './DocPages/Caching/Client.tsx';
+// import CachingErrors from './DocPages/Caching/Errors.tsx';
+// import Server from './DocPages/Caching/Server.tsx';
+// import Strategies from './DocPages/Caching/Strategies.tsx';
 
 import SideBar from './SideBar.tsx';
 
@@ -37,20 +37,20 @@ const Docs = (props: any) => {
   if (docsPage === 'Overview') curDocsPage = <Overview />;
   if (docsPage === 'Philosophy') curDocsPage = <Philosophy />;
 
-  if (docsPage === 'Persistence') curDocsPage = <Persistence />;
-  if (docsPage === 'Polling') curDocsPage = <Polling />;
-  if (docsPage === 'Subscriptions') curDocsPage = <Subscriptions />;
+  // if (docsPage === 'Persistence') curDocsPage = <Persistence />;
+  // if (docsPage === 'Polling') curDocsPage = <Polling />;
+  // if (docsPage === 'Subscriptions') curDocsPage = <Subscriptions />;
 
-  if (docsPage === 'BasicsErrors') curDocsPage = <BasicsErrors setDocsPage={setDocsPage} />;
-  if (docsPage === 'GettingStarted') curDocsPage = <GettingStarted setDocsPage={setDocsPage} />;
-  if (docsPage === 'Mutations') curDocsPage = <Mutations setDocsPage={setDocsPage} />;
-  if (docsPage === 'Queries') curDocsPage = <Queries setDocsPage={setDocsPage} />;
-  if (docsPage === 'ServerSideRendering') curDocsPage = <ServerSideRendering />;
+  // if (docsPage === 'BasicsErrors') curDocsPage = <BasicsErrors setDocsPage={setDocsPage} />;
+  // if (docsPage === 'GettingStarted') curDocsPage = <GettingStarted setDocsPage={setDocsPage} />;
+  // if (docsPage === 'Mutations') curDocsPage = <Mutations setDocsPage={setDocsPage} />;
+  // if (docsPage === 'Queries') curDocsPage = <Queries setDocsPage={setDocsPage} />;
+  // if (docsPage === 'ServerSideRendering') curDocsPage = <ServerSideRendering />;
 
-  if (docsPage === 'Client') curDocsPage = <Client setDocsPage={setDocsPage} />;
-  if (docsPage === 'CachingErrors') curDocsPage = <CachingErrors />;
-  if (docsPage === 'Server') curDocsPage = <Server />;
-  if (docsPage === 'Strategies') curDocsPage = <Strategies setDocsPage={setDocsPage} />;
+  // if (docsPage === 'Client') curDocsPage = <Client setDocsPage={setDocsPage} />;
+  // if (docsPage === 'CachingErrors') curDocsPage = <CachingErrors />;
+  // if (docsPage === 'Server') curDocsPage = <Server />;
+  // if (docsPage === 'Strategies') curDocsPage = <Strategies setDocsPage={setDocsPage} />;
 
   return (
     <>

--- a/deps.ts
+++ b/deps.ts
@@ -6,12 +6,12 @@ import ReactDom from 'https://dev.jspm.io/react-dom';
 //   useObsidian,
 // } from 'https://deno.land/x/obsidian@v1.0.1/clientMod.ts';
 
-import rcb from 'https://dev.jspm.io/react-code-blocks';
+// import rcb from 'https://dev.jspm.io/react-code-blocks';
 
-const realRCB: any = rcb;
-const { CodeBlock, CopyBlock, monokai } = realRCB;
+// const realRCB: any = rcb;
+// const { CodeBlock, CopyBlock, monokai } = realRCB;
 
-monokai.backgroundColor = 'rgba(5, 5, 5, 0.93)';
+// monokai.backgroundColor = 'rgba(5, 5, 5, 0.93)';
 
 export {
   React,
@@ -19,7 +19,7 @@ export {
   ReactDom,
   // ObsidianWrapper,
   // useObsidian,
-  CodeBlock,
-  CopyBlock,
-  monokai,
+  // CodeBlock,
+  // CopyBlock,
+  // monokai,
 };

--- a/server.tsx
+++ b/server.tsx
@@ -93,8 +93,8 @@ function handlePage(ctx: any) {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
-    <link href="/static/prism.css" rel="stylesheet" />
     <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.22.0/prism.min.js">
     <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
@@ -114,3 +114,6 @@ function handlePage(ctx: any) {
     console.error(error);
   }
 }
+
+
+{/* <link href="/static/prism.css" rel="stylesheet" /> */}


### PR DESCRIPTION
Blocked import of Code Blocks library.

Most docs pages are commented out for now until next patch.

Overview, Philosophy, and Quick Start are alive. Quick Start has plain code in place of stylized code blocks. 

Next step is creating custom code block component.

Also, added another link to html to attempt working with Prism.js, but not active as of yet.