### PR TITLE
Modify docker compose to simplify Elastic Beanstalk implementation and use default load balancer port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
         volumes:
             - ./:/usr/app
         ports:
-            - "3000:3000"
+            - "80:3000"


### PR DESCRIPTION

Co-authored-by: justinwmckay <justinmckay99@gmail.com>
Co-authored-by: kyunglee1 <kyunglee3@yahoo.com>
Co-authored-by: raymondcodes <ray.ahn@gmail.com>
Co-authored-by: cssim22 <cssim22@gmail.com>
Co-authored-by: pjmsullivan <patrick@jsullivan.org>